### PR TITLE
[FRONTEND] Feat: react-icons 설치

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.9.0",
         "react-redux": "^8.0.7",
         "react-router-dom": "^6.13.0",
         "styled-components": "^6.0.0-rc.3",
@@ -6824,6 +6825,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
+      "integrity": "sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "clsx": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.9.0",
     "react-redux": "^8.0.7",
     "react-router-dom": "^6.13.0",
     "styled-components": "^6.0.0-rc.3",


### PR DESCRIPTION
## 작업 사항
react-icons를 설치했습니다.

## 설치 과정
`npm install react-icons --save`

참고: [공식문서](https://react-icons.github.io/react-icons)