### PR TITLE
[FRONT] RightSideBar 깨짐 현상 해결

### DIFF
--- a/client/src/common/basic/SideBarAd.tsx
+++ b/client/src/common/basic/SideBarAd.tsx
@@ -21,8 +21,8 @@ const AdImage = styled.img`
 const IconWrapper = styled.div`
     position: absolute;
     cursor: pointer;
-    top: 0.5px;
-    left: 277px;
+    top: 1px;
+    left: 249px;
     z-index: 10;
 
     & svg {

--- a/client/src/common/basic/Widget.tsx
+++ b/client/src/common/basic/Widget.tsx
@@ -8,12 +8,12 @@ interface WidgetProps extends WidgetData{
     children: ReactNode;
 };
 
-const WidgetContainer = styled.div<{type:string|undefined, idx:number, isStuck:boolean|undefined}>`
+const WidgetContainer = styled.div<{type:string|undefined, idx:number, isstuck:boolean|undefined}>`
     height  : 100%;
     border: 1px solid;
     border-radius: 3px 3px 0 0;
 
-    ${(props) => props.isStuck &&
+    ${(props) => props.isstuck &&
         css`
             border-radius: ${props.idx !== 1 && '0'};
             border-top: ${props.idx !== 1 && '0px'};
@@ -63,7 +63,7 @@ const WidgetHeader = styled.div<{type:string|undefined}>`
 
 const Widget = ({id, type, isstuck, title, children}:WidgetProps) => {
     return(
-        <WidgetContainer type={type} idx={id} isStuck={isstuck}>
+        <WidgetContainer type={type} idx={id} isstuck={isstuck}>
             <WidgetHeader type={type}>{title}</WidgetHeader>
             {children}
         </WidgetContainer>

--- a/client/src/common/style/Containers.styled.tsx
+++ b/client/src/common/style/Containers.styled.tsx
@@ -18,6 +18,7 @@ export const ContentContainer = styled.div<{size:number|string, direction:string
 
 export const ColumnItemWrapper = styled.div<{size:number|string, gap:number, align?:string|undefined}>`
     width: ${(props) => typeof props.size === 'string' ? props.size : `${props.size}px`};
+    height: 100%;
     ${ (props) => props.align === 'center' ?
       FlexColumnCenter
       :

--- a/client/src/pages/question/QuestionsPage.tsx
+++ b/client/src/pages/question/QuestionsPage.tsx
@@ -11,7 +11,7 @@ interface QuestionsPageProps {
 const QuestionsPage = ({}: QuestionsPageProps) => {
   return (
     <Wrapper>
-      <main className=" flex px-6 py-3">
+      <main className="flex px-6 py-3">
         <LeftSideBar />
         <QuestionContainer />
         <RightSideBar/>


### PR DESCRIPTION
* `ColumnItemsWrapper` 스타일드 컴포넌트에 `height:100%` 속성을 주지 않아서 일어난 현상이었습니다.