### PR TITLE
[FRONT] 질문, 답변 Edit 버튼 클릭 시 페이지 이동

### DIFF
--- a/client/src/components/askdetail/QuestionAnswerComponent.tsx
+++ b/client/src/components/askdetail/QuestionAnswerComponent.tsx
@@ -33,6 +33,13 @@ const QuestionAnswerComponent = ({type, data, questionId, answerId, refetch}: Qu
     }
   });
 
+  const gotoEditPage = ()=>{
+    if(type === 'Question')
+      window.location.href = `/questions/${questionId}/edit`;
+    if(type === 'Answer')
+      window.location.href = `/answers/${answerId}/edit`;
+  }
+
   return (
     <section className="">
       <div className=" flex pt-4 mb-6">
@@ -45,7 +52,7 @@ const QuestionAnswerComponent = ({type, data, questionId, answerId, refetch}: Qu
           :
           `/questions/${questionId}/answers/${answerId}`
           }>
-          <button>Edit</button>
+          <button onClick={gotoEditPage}>Edit</button>
         </Link>
         <button onClick={()=>mutate()}>Delete</button>
       </div>


### PR DESCRIPTION
# 작업 내용
* QuestionDetailPage 에서 질문/답변에 Edit 버튼 클릭 시 수정 페이지로 이동하는 클릭 이벤트 리스너를 등록하였습니다.
* 수정 페이지 라우터 경로가 안 정해진 것 같아서 임시로 아래와 같이 적어두었습니다.
  * 질문 수정 페이지로 이동 : `/questions/${questionId}/edit`
  * 답변 수정 페이지로 이동 : `/answers/${answerId}/edit` 