### PR TITLE
[FRONT] Create Question and Answer Edit Page 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,8 @@ import UserPage from './pages/userInfo/UserPage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import QuestionEditPage from './pages/question/[id]/questionedit/QuestionEditPage';
+import AnswerEditPage from './pages/question/[id]/answeredit/[answerid]/AnswerEditPage';
 
 const queryClient = new QueryClient();
 
@@ -17,22 +19,27 @@ interface AppProps {}
 const App = ({}: AppProps) => {
   return (
     <QueryClientProvider client={queryClient}>
-    <BrowserRouter>
-    <div className="flex flex-col min-h-screen">
-        <Header changeNav={true}/>
-        <main className="flex-grow">
+      <BrowserRouter>
+        <div className="flex min-h-screen flex-col">
+          <Header changeNav={true} />
+          <main className="flex-grow">
             <Routes>
-              <Route path="/" element={<QuestionsPage/>}/>
-              <Route path="/questions/ask" element={<AskQuestionPage/>}/>
-              <Route path="/questions/:questionId" element={<QuestionDetailPage/>}/>
-              <Route path="/users" element={<UserPage/>}/>
-              <Route path="/users/login" element={<LoginPage/>}/>
-              <Route path="/users/signup" element={<SignupPage/>}/>
+              <Route path="/" element={<QuestionsPage />} />
+              <Route path="/questions/ask" element={<AskQuestionPage />} />
+              <Route path="/questions/:questionid" element={<QuestionDetailPage />} />
+              <Route path="/questions/:questionid/questionedit" element={<QuestionEditPage />} />
+              <Route
+                path="/questions/:questionid/answeredit/:answerid"
+                element={<AnswerEditPage />}
+              />
+              <Route path="/users" element={<UserPage />} />
+              <Route path="/users/login" element={<LoginPage />} />
+              <Route path="/users/signup" element={<SignupPage />} />
             </Routes>
           </main>
-        <Footer/>
-      </div>
-    </BrowserRouter>
+          <Footer />
+        </div>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 };

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -40,7 +40,6 @@ const LoginPage = () => {
   const loginMutation = useLoginMutation();
   const loginForm = useForm<LoginType>({ resolver: zodResolver(loginSchema) });
   const onSubmit: SubmitHandler<LoginType> = (data) => {
-    console.log(data);
     loginMutation.mutate(data);
   };
 

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -37,8 +37,8 @@ export type SignupType = z.infer<typeof signupSchema>;
 const SignupPage = () => {
   const signupMutation = useSignupMutation();
   const signupForm = useForm<SignupType>({ resolver: zodResolver(signupSchema) });
-  const onSubmit: SubmitHandler<SignupType> = async (data) => {
-    const mutate = await signupMutation.mutateAsync(data);
+  const onSubmit: SubmitHandler<SignupType> = (data) => {
+    signupMutation.mutate(data);
   };
 
   return (

--- a/client/src/pages/question/[id]/answeredit/[answerid]/AnswerEditPage.tsx
+++ b/client/src/pages/question/[id]/answeredit/[answerid]/AnswerEditPage.tsx
@@ -1,6 +1,7 @@
 import useQnAPatchMutation, { PatchInterface } from '@/queries/useQnAPatchMutation';
 import { useParams, useNavigate } from 'react-router-dom';
 import React, { useRef } from 'react';
+import Wrapper from '@/common/Wrapper';
 
 interface AnswerEditPageProps {}
 
@@ -39,54 +40,56 @@ const AnswerEditPage = ({}: AnswerEditPageProps) => {
   };
 
   return (
-    <main className="m-5 flex flex-row">
-      <div className="flex flex-col">
-        <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
-          {EditDatas.editdescription.map((description) => (
-            <span key={description}>{description}</span>
-          ))}
-        </div>
+    <Wrapper>
+      <main className="m-5 flex flex-row">
+        <div className="flex flex-col">
+          <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
+            {EditDatas.editdescription.map((description) => (
+              <span key={description}>{description}</span>
+            ))}
+          </div>
 
-        <div className="mb-2">
-          <div className=" mb-3 mt-4 rounded-sm ">Body</div>
-          <textarea
-            className=" min-h-[243px] w-full overflow-visible rounded-md
+          <div className="mb-2">
+            <div className=" mb-3 mt-4 rounded-sm ">Body</div>
+            <textarea
+              className=" min-h-[243px] w-full overflow-visible rounded-md
                                     border border-slate-300 px-3 py-2 text-xs"
-            ref={bodyRef}
-            required
-          ></textarea>
-        </div>
+              ref={bodyRef}
+              required
+            ></textarea>
+          </div>
 
-        <div className="my-4 mb-3 text-sm ">
-          <button
-            className="rounded border border-zinc-200 bg-blue-500 px-3 
+          <div className="my-4 mb-3 text-sm ">
+            <button
+              className="rounded border border-zinc-200 bg-blue-500 px-3 
                         py-2 font-normal text-white hover:bg-blue-800"
-            onClick={saveEditHandler}
-          >
-            Save edits
-          </button>
-          <button
-            className="mx-2 bg-white px-3 py-2 font-normal 
+              onClick={saveEditHandler}
+            >
+              Save edits
+            </button>
+            <button
+              className="mx-2 bg-white px-3 py-2 font-normal 
                             text-sky-500 hover:rounded hover:bg-sky-50"
-          >
-            Cancel
-          </button>
+            >
+              Cancel
+            </button>
+          </div>
         </div>
-      </div>
 
-      <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
-        <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
-          How to Edit
+        <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
+          <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
+            How to Edit
+          </div>
+          <ul className="list-disc py-2 pl-8 text-xs">
+            {EditDatas.howtoeditlist.map((edit) => (
+              <li className=" py-2 pl-2" key={edit}>
+                {edit}
+              </li>
+            ))}
+          </ul>
         </div>
-        <ul className="list-disc py-2 pl-8 text-xs">
-          {EditDatas.howtoeditlist.map((edit) => (
-            <li className=" py-2 pl-2" key={edit}>
-              {edit}
-            </li>
-          ))}
-        </ul>
-      </div>
-    </main>
+      </main>
+    </Wrapper>
   );
 };
 

--- a/client/src/pages/question/[id]/answeredit/[answerid]/AnswerEditPage.tsx
+++ b/client/src/pages/question/[id]/answeredit/[answerid]/AnswerEditPage.tsx
@@ -1,0 +1,93 @@
+import useQnAPatchMutation, { PatchInterface } from '@/queries/useQnAPatchMutation';
+import { useParams, useNavigate } from 'react-router-dom';
+import React, { useRef } from 'react';
+
+interface AnswerEditPageProps {}
+
+const EditDatas = {
+  editdescription: [
+    'Your edit will be placed in a queue until it is peer reviewed.',
+    'We welcome edits that make the post easier to understand and more valuable for readers. Because community members review edits, please try to make the post substantially better than how you found it, for example, by fixing grammar or adding additional resources and hyperlinks.',
+  ],
+  howtoeditlist: [
+    'Correct minor typos or mistakes',
+    'Clarify meaning without changing it',
+    'Add related resources or links',
+    "Always respect the authors'intent",
+    "Don't use edits to reply to the author",
+  ],
+};
+
+const AnswerEditPage = ({}: AnswerEditPageProps) => {
+  const answerMutation = useQnAPatchMutation();
+  const { questionid, answerid } = useParams();
+  const navigate = useNavigate();
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const saveEditHandler = () => {
+    const answerObj: PatchInterface = {
+      type: 'answer',
+      id: {
+        'question-id': questionid,
+        'answer-id': answerid,
+      },
+      body: {
+        'qeustion-content': bodyRef.current.value,
+      },
+    };
+    answerMutation.mutate(answerObj);
+    navigate(`/questions/${questionid}`);
+  };
+
+  return (
+    <main className="m-5 flex flex-row">
+      <div className="flex flex-col">
+        <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
+          {EditDatas.editdescription.map((description) => (
+            <span key={description}>{description}</span>
+          ))}
+        </div>
+
+        <div className="mb-2">
+          <div className=" mb-3 mt-4 rounded-sm ">Body</div>
+          <textarea
+            className=" min-h-[243px] w-full overflow-visible rounded-md
+                                    border border-slate-300 px-3 py-2 text-xs"
+            ref={bodyRef}
+            required
+          ></textarea>
+        </div>
+
+        <div className="my-4 mb-3 text-sm ">
+          <button
+            className="rounded border border-zinc-200 bg-blue-500 px-3 
+                        py-2 font-normal text-white hover:bg-blue-800"
+            onClick={saveEditHandler}
+          >
+            Save edits
+          </button>
+          <button
+            className="mx-2 bg-white px-3 py-2 font-normal 
+                            text-sky-500 hover:rounded hover:bg-sky-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
+        <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
+          How to Edit
+        </div>
+        <ul className="list-disc py-2 pl-8 text-xs">
+          {EditDatas.howtoeditlist.map((edit) => (
+            <li className=" py-2 pl-2" key={edit}>
+              {edit}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+};
+
+export default AnswerEditPage;

--- a/client/src/pages/question/[id]/questionedit/QuestionEditPage.tsx
+++ b/client/src/pages/question/[id]/questionedit/QuestionEditPage.tsx
@@ -1,0 +1,123 @@
+import AmendQuestion from '@/components/amendQuestion/AmendQuestion';
+import useQnAPatchMutation, { PatchInterface } from '@/queries/useQnAPatchMutation';
+import React from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+
+interface QuestionEditPageProps {}
+
+const EditDatas = {
+  editdescription: [
+    'Your edit will be placed in a queue until it is peer reviewed.',
+    'We welcome edits that make the post easier to understand and more valuable for readers. Because community members review edits, please try to make the post substantially better than how you found it, for example, by fixing grammar or adding additional resources and hyperlinks.',
+  ],
+  howtoeditlist: [
+    'Correct minor typos or mistakes',
+    'Clarify meaning without changing it',
+    'Add related resources or links',
+    "Always respect the authors'intent",
+    "Don't use edits to reply to the author",
+  ],
+};
+
+interface QuestionFormType {
+  title: string;
+  body: string;
+  tags: { tagname: string }[];
+}
+
+const QuestionEditPage = ({}: QuestionEditPageProps) => {
+  const { questionid } = useParams();
+  const questionMutation = useQnAPatchMutation();
+  const navigate = useNavigate();
+  const questionForm = useForm<QuestionFormType>();
+  const onSubmit: SubmitHandler<QuestionFormType> = (data) => {
+    const questionObj: PatchInterface = {
+      type: 'question',
+      id: {
+        'question-id': questionid,
+      },
+      body: {
+        'question-title': data.title,
+        'qeustion-content': data.body,
+        tags: [],
+      },
+    };
+    questionMutation.mutate(questionObj);
+    navigate(`/questions/${questionid}`);
+  };
+
+  return (
+    <main className="m-5 flex flex-row">
+      <div className="flex flex-col">
+        <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
+          {EditDatas.editdescription.map((description) => (
+            <span key={description}>{description}</span>
+          ))}
+        </div>
+        <form onSubmit={questionForm.handleSubmit(onSubmit)}>
+          <div className="mb-2">
+            <div className=" mb-3 mt-4 rounded-sm ">Title</div>
+            <input
+              type="text"
+              className=" w-full rounded-md border border-slate-300 
+                            px-3 py-2 text-xs"
+              maxLength={20}
+              {...questionForm.register('title')}
+            />
+          </div>
+
+          <div className="mb-2">
+            <div className=" mb-3 mt-4 rounded-sm ">Body</div>
+            <textarea
+              className=" min-h-[243px] w-full overflow-visible rounded-md
+                                    border border-slate-300 px-3 py-2 text-xs"
+              {...questionForm.register('body')}
+            />
+          </div>
+
+          <div className="mb-2">
+            <div className=" mb-3 mt-4 rounded-sm ">Tags</div>
+            <input
+              type="text"
+              className=" w-full rounded-md border border-slate-300 
+                            px-3 py-2 text-xs "
+              placeholder="e.g.(pandas spring swift)"
+              {...questionForm.register('tags')}
+            />
+          </div>
+
+          <div className="my-4 mb-3 text-sm ">
+            <button
+              type="submit"
+              className="rounded border border-zinc-200 bg-blue-500 px-3 
+                        py-2 font-normal text-white hover:bg-blue-800"
+            >
+              Save edits
+            </button>
+            <button
+              className="mx-2 bg-white px-3 py-2 font-normal 
+                            text-sky-500 hover:rounded hover:bg-sky-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+      <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
+        <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
+          How to Edit
+        </div>
+        <ul className="list-disc py-2 pl-8 text-xs">
+          {EditDatas.howtoeditlist.map((edit) => (
+            <li className=" py-2 pl-2" key={edit}>
+              {edit}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+};
+
+export default QuestionEditPage;

--- a/client/src/pages/question/[id]/questionedit/QuestionEditPage.tsx
+++ b/client/src/pages/question/[id]/questionedit/QuestionEditPage.tsx
@@ -1,3 +1,4 @@
+import Wrapper from '@/common/Wrapper';
 import AmendQuestion from '@/components/amendQuestion/AmendQuestion';
 import useQnAPatchMutation, { PatchInterface } from '@/queries/useQnAPatchMutation';
 import React from 'react';
@@ -48,75 +49,77 @@ const QuestionEditPage = ({}: QuestionEditPageProps) => {
   };
 
   return (
-    <main className="m-5 flex flex-row">
-      <div className="flex flex-col">
-        <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
-          {EditDatas.editdescription.map((description) => (
-            <span key={description}>{description}</span>
-          ))}
-        </div>
-        <form onSubmit={questionForm.handleSubmit(onSubmit)}>
-          <div className="mb-2">
-            <div className=" mb-3 mt-4 rounded-sm ">Title</div>
-            <input
-              type="text"
-              className=" w-full rounded-md border border-slate-300 
+    <Wrapper>
+      <main className="m-5 flex flex-row">
+        <div className="flex flex-col">
+          <div className="flex max-w-[661px] flex-col gap-3 border border-amber-200 bg-amber-100 bg-opacity-50 px-6 pb-6 pt-4 text-sm font-light">
+            {EditDatas.editdescription.map((description) => (
+              <span key={description}>{description}</span>
+            ))}
+          </div>
+          <form onSubmit={questionForm.handleSubmit(onSubmit)}>
+            <div className="mb-2">
+              <div className=" mb-3 mt-4 rounded-sm ">Title</div>
+              <input
+                type="text"
+                className=" w-full rounded-md border border-slate-300 
                             px-3 py-2 text-xs"
-              maxLength={20}
-              {...questionForm.register('title')}
-            />
-          </div>
+                maxLength={20}
+                {...questionForm.register('title')}
+              />
+            </div>
 
-          <div className="mb-2">
-            <div className=" mb-3 mt-4 rounded-sm ">Body</div>
-            <textarea
-              className=" min-h-[243px] w-full overflow-visible rounded-md
+            <div className="mb-2">
+              <div className=" mb-3 mt-4 rounded-sm ">Body</div>
+              <textarea
+                className=" min-h-[243px] w-full overflow-visible rounded-md
                                     border border-slate-300 px-3 py-2 text-xs"
-              {...questionForm.register('body')}
-            />
-          </div>
+                {...questionForm.register('body')}
+              />
+            </div>
 
-          <div className="mb-2">
-            <div className=" mb-3 mt-4 rounded-sm ">Tags</div>
-            <input
-              type="text"
-              className=" w-full rounded-md border border-slate-300 
+            <div className="mb-2">
+              <div className=" mb-3 mt-4 rounded-sm ">Tags</div>
+              <input
+                type="text"
+                className=" w-full rounded-md border border-slate-300 
                             px-3 py-2 text-xs "
-              placeholder="e.g.(pandas spring swift)"
-              {...questionForm.register('tags')}
-            />
-          </div>
+                placeholder="e.g.(pandas spring swift)"
+                {...questionForm.register('tags')}
+              />
+            </div>
 
-          <div className="my-4 mb-3 text-sm ">
-            <button
-              type="submit"
-              className="rounded border border-zinc-200 bg-blue-500 px-3 
+            <div className="my-4 mb-3 text-sm ">
+              <button
+                type="submit"
+                className="rounded border border-zinc-200 bg-blue-500 px-3 
                         py-2 font-normal text-white hover:bg-blue-800"
-            >
-              Save edits
-            </button>
-            <button
-              className="mx-2 bg-white px-3 py-2 font-normal 
+              >
+                Save edits
+              </button>
+              <button
+                className="mx-2 bg-white px-3 py-2 font-normal 
                             text-sky-500 hover:rounded hover:bg-sky-50"
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      </div>
-      <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
-        <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
-          How to Edit
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
         </div>
-        <ul className="list-disc py-2 pl-8 text-xs">
-          {EditDatas.howtoeditlist.map((edit) => (
-            <li className=" py-2 pl-2" key={edit}>
-              {edit}
-            </li>
-          ))}
-        </ul>
-      </div>
-    </main>
+        <div className="ml-5 flex max-h-[223px] min-w-[352px] flex-col  border border-orange-100 bg-amber-100 bg-opacity-50 text-sm md:block md:w-auto">
+          <div className="border-b border-orange-100 bg-amber-100 py-2 pl-5 font-normal">
+            How to Edit
+          </div>
+          <ul className="list-disc py-2 pl-8 text-xs">
+            {EditDatas.howtoeditlist.map((edit) => (
+              <li className=" py-2 pl-2" key={edit}>
+                {edit}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    </Wrapper>
   );
 };
 

--- a/client/src/queries/useLoginMutation.tsx
+++ b/client/src/queries/useLoginMutation.tsx
@@ -13,8 +13,7 @@ const postLogin = async (loginData: any) => {
     body: JSON.stringify(loginData),
     credentials: 'include',
     headers: {
-      Origin: 'http://localhost:5173',
-      'Access-Control-Request-Method': 'POST',
+      'Content-Type': 'application/json;charset=utf-8',
     },
   });
   const header = getHeader(response, 'authorization');

--- a/client/src/queries/useLogoutMutation.tsx
+++ b/client/src/queries/useLogoutMutation.tsx
@@ -11,7 +11,6 @@ const url = '';
 const getLogout = async () => {
   const response = await fetch(`${url}/users/logout`);
   const result = await response.json();
-  console.log(result);
   return result;
 };
 

--- a/client/src/queries/useQnAPatchMutation.tsx
+++ b/client/src/queries/useQnAPatchMutation.tsx
@@ -13,7 +13,7 @@ export interface PatchInterface {
   };
 }
 
-const url = '';
+const url = 'http://ec2-3-35-27-217.ap-northeast-2.compute.amazonaws.com:8080';
 
 const urlCreator = (baseurl: string, patchData: PatchInterface) => {
   switch (patchData.type) {
@@ -32,11 +32,11 @@ const patchQnA = async (patchData: PatchInterface) => {
     method: 'PATCH',
     body: JSON.stringify(patchData),
     headers: {
-      Origin: 'http://localhost:5173',
-      'Access-Control-Request-Method': 'PATCH',
+      'Content-Type': 'application/json;charset=utf-8',
     },
   });
   const result = await response;
+  console.log(result);
   return result;
 };
 

--- a/client/src/queries/useQnAPatchMutation.tsx
+++ b/client/src/queries/useQnAPatchMutation.tsx
@@ -7,9 +7,9 @@ export interface PatchInterface {
     'answer-id'?: number | string;
   };
   body: {
-    'question-title': string;
+    'question-title'?: string;
     'qeustion-content': string;
-    tags: { 'tag-name': string }[];
+    tags?: { 'tag-name': string }[];
   };
 }
 

--- a/client/src/queries/useSignupMutation.tsx
+++ b/client/src/queries/useSignupMutation.tsx
@@ -2,21 +2,24 @@ import { SignupType } from '@/pages/SignupPage';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-const url = '';
+const url = 'http://ec2-3-35-27-217.ap-northeast-2.compute.amazonaws.com:8080';
 
 const postSignup = async (signupData: SignupType) => {
   const response = await fetch(`${url}/users/signup`, {
     method: 'POST',
     body: JSON.stringify(signupData),
-    credentials: 'include',
     headers: {
       Origin: 'http://localhost:5173',
       'Access-Control-Request-Method': 'POST',
+      'Content-Type': 'application/json;charset=utf-8',
     },
+
+    credentials: 'include',
   });
 
   // const header = getHeader(response, 'authorization');
   const result = await response.json();
+  console.log('회원가입', result);
   return result;
 };
 

--- a/client/src/queries/useSignupMutation.tsx
+++ b/client/src/queries/useSignupMutation.tsx
@@ -9,17 +9,12 @@ const postSignup = async (signupData: SignupType) => {
     method: 'POST',
     body: JSON.stringify(signupData),
     headers: {
-      Origin: 'http://localhost:5173',
-      'Access-Control-Request-Method': 'POST',
       'Content-Type': 'application/json;charset=utf-8',
     },
-
-    credentials: 'include',
   });
 
   // const header = getHeader(response, 'authorization');
   const result = await response.json();
-  console.log('회원가입', result);
   return result;
 };
 


### PR DESCRIPTION
 # 개요

Question Edit과 Answer Edit Page에 대한 Pull Request입니다.


# 미완 된 부분

1. tag의 입력이 구현 되어 있지 않아 tag는 더미데이터를 patch 하도록 했습니다.

2. 금일 10:10 에 dev branch를 pull 받았는데 이 당시 시점에선 상세 페이지가 동작하지 않았습니다.

따라서 상세페이지 내부에서 edit 으로 이동하는 버튼을 테스트할 수 없어 냅뒀습니다.

3. 2와 마찬가지로 상세 페이지가 동작하지 않았기에 상세페이지의 데이터를 받아 수정화면에서 수정할 데이터를 띄워줄 수 없었습니다.


# 완성된 부분

## answer edit page


![answeredit](https://github.com/codestates-seb/seb44_pre_027/assets/101111364/1faa827f-aa7a-407f-afa9-0a62b933613a)


endpoint는 우선

```
/questions/:questionid/answeredit/:answerid
```
이렇게 정의해두었는데 혹시 정해둔 컨벤션이 있다면 약간 수정하면 될 것 같습니다.


## questionedit page

![questionedit](https://github.com/codestates-seb/seb44_pre_027/assets/101111364/cc2f4d98-1063-4111-b96a-86af03596106)

```
/questions/:questionid/questionedit
```

우선 정의한 엔드포인트는 다음과 같습니다.

이 역시 마찬가지로 필요 시 변경하면 될듯합니다.

상세페이지 영역에서는

edit 버튼을 클릭했을때 해당 엔드포인트로 link 될 수 있게만 작성해주면 될것같습니다.