### PR TITLE
[FRONT]페이지네이션 버튼 수정

### DIFF
--- a/client/src/components/home/PagenationBtn.tsx
+++ b/client/src/components/home/PagenationBtn.tsx
@@ -32,7 +32,7 @@ interface PagenationBtnProps
 }
 
 const PagenationBtn = ({ children, className, variant,total, basic,setBasic, ...attributes }: PagenationBtnProps) => {
-
+  
   return (
     <button 
     className={`${cn(ButtonVariants({ variant }))} ${className}`} {...attributes}

--- a/client/src/components/home/QuestionContainer.tsx
+++ b/client/src/components/home/QuestionContainer.tsx
@@ -22,6 +22,7 @@ const QuestionContainer = () => {
   // btn 클릭 시 page변동 및 get요청 
   const lastPage = (basic-1)*curpage + curpage;
 
+  //현재 페이지 적용
   const handlePage = (pageNum:number) => {
     setBasic(pageNum);
   }; 
@@ -77,42 +78,14 @@ const QuestionContainer = () => {
       })
       }
 
-      <div className=" mx-24 mb-24 mt-12 flex">
-      {basic > 5 && (
-        <PagenationBtn onClick={() => handlePage(1)}>
-          1
-        </PagenationBtn>
-      )}
-      {basic > 5 && (
-        <PagenationBtn onClick={() => handlePage(basic - 1)}>
-          &lt;
-        </PagenationBtn>
-      )}
-      {Array.from({ length: 5 }).map((_, i) => {
-        const pageNumber = basic - (5 - i);
-        if (pageNumber > 0) {
-          return (
-            <PagenationBtn
-              total={data.length}
-              basic={basic}
-              setBasic={setBasic}
-              variant={basic === pageNumber ? 'active' : 'default'}
-              key={i}
-              onClick={() => handlePage(pageNumber)}
-            >
-              {pageNumber}
-            </PagenationBtn>
-          );
-        }
-        return null;
-      })}
-      {basic <= 5 && (
-        <PagenationBtn onClick={handleNextPage}>
-          &gt;
-        </PagenationBtn>
-      )}
-        {/* {Array.from({length:5}).map((e,i) => {
+      <div className=" mx-24 mb-24 mt-12 flex justify-center">
+      <PagenationBtn onClick={() => setBasic(basic-1)} >
+      &lt;
+      </PagenationBtn>
+      {Array.from({length: data.length}).map((e, i) => {
           const pageNumber = i + 1;
+          // console.log('num' + numPages);
+          // console.log(pageNumber);
           if(pageNumber <= 5){
             return(
               <PagenationBtn
@@ -124,19 +97,25 @@ const QuestionContainer = () => {
                 onClick={()=> handlePage(pageNumber)}
               >{pageNumber}</PagenationBtn>
             );
+          }else if (pageNumber > 5){
+            return(
+              <PagenationBtn
+                total={data.length}
+                basic={basic}
+                setBasic={setBasic}
+                variant={basic === pageNumber ? 'active' : 'default'}
+                key={i} // key 속성 추가
+                onClick={()=> handlePage(pageNumber)}
+              > {} </PagenationBtn>
+            );
           }
+         
 
-          return (
-            <PagenationBtn
-              total={data.length}
-              basic={basic}
-              setBasic={setBasic}
-              variant={basic === pageNumber ? 'active' : 'default'}
-              key={i} // key 속성 추가
-              onClick={()=> handlePage(pageNumber)}
-            >{pageNumber}</PagenationBtn>
-          )
-        })}; */}
+        })}
+      <PagenationBtn onClick={() => setBasic(basic+1)} >
+      &gt;
+      </PagenationBtn>
+        
       </div>
     </main>
   );


### PR DESCRIPTION
# 페이지네이션 버튼 수정

다음 버튼을 추가하여 1 페이지의 5 다음 글도 볼 수 있게 구현하였습니다. 

# 수정 필요 사항 
데이터를 5개 단위로 잘라서 받기 때문에 현재 버튼 부분에는 알맞은 페이지 정보가 적용 되고 있지 않습니다. 